### PR TITLE
feat: Prompt user to install MetaMask and provide download link

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -37,7 +37,9 @@ function App() {
           await window.ethereum.request({ method: 'eth_requestAccounts' });
           await fetchBalance(); 
         } else {
-          alert('Por favor, instale o MetaMask para usar esta aplicação.');
+          if (window.confirm('Por favor, instale o MetaMask para usar esta aplicação. Você gostaria de visitar a página de download?')) {
+            window.open('https://metamask.io/download/', '_blank');
+          }
         }
       } catch (error) {
         console.error('Error connecting to MetaMask:', error);

--- a/src/web3Utils.js
+++ b/src/web3Utils.js
@@ -25,7 +25,9 @@ if (window.ethereum) {
     window.location.reload(); // Recarrega a página ao detectar mudança na rede
   });
 } else {
-  alert('Por favor, instale o MetaMask para usar esta aplicação.');
+  if (window.confirm('Por favor, instale o MetaMask para usar esta aplicação. Você gostaria de visitar a página de download?')) {
+    window.open('https://metamask.io/download/', '_blank');
+  }
 }
 
 export { web3, contract };


### PR DESCRIPTION
This commit adds a prompt to the application when MetaMask is not detected. Instead of just showing an alert, it now displays a confirmation dialog with the option to visit the MetaMask download page. If the user chooses to visit the page, it opens the download link in a new tab.